### PR TITLE
 Switching from @Assert to @Assertion 

### DIFF
--- a/src/Annotations/Assertion.php
+++ b/src/Annotations/Assertion.php
@@ -20,7 +20,7 @@ use function ltrim;
  *   @Attribute("constraint", type = "Symfony\Component\Validator\Constraint[]|Symfony\Component\Validator\Constraint")
  * })
  */
-class Assert implements ParameterAnnotationInterface
+class Assertion implements ParameterAnnotationInterface
 {
     /** @var string */
     private $for;

--- a/src/Mappers/Parameters/AssertParameterMiddleware.php
+++ b/src/Mappers/Parameters/AssertParameterMiddleware.php
@@ -51,7 +51,7 @@ class AssertParameterMiddleware implements ParameterMiddlewareInterface
         }
 
         if (! $parameter instanceof InputTypeParameterInterface) {
-            throw InvalidAssertAnnotationException::canOnlyValidateInputType($refParameter);
+            throw InvalidAssertionAnnotationException::canOnlyValidateInputType($refParameter);
         }
 
         // Let's wrap the ParameterInterface into a ParameterValidator.

--- a/src/Mappers/Parameters/AssertParameterMiddleware.php
+++ b/src/Mappers/Parameters/AssertParameterMiddleware.php
@@ -16,6 +16,7 @@ use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMiddlewareInterface;
 use TheCodingMachine\GraphQLite\Parameters\InputTypeParameterInterface;
 use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
 use TheCodingMachine\Graphqlite\Validator\Annotations\Assert;
+use TheCodingMachine\Graphqlite\Validator\Annotations\Assertion;
 use function array_map;
 use function array_merge;
 
@@ -40,12 +41,12 @@ class AssertParameterMiddleware implements ParameterMiddlewareInterface
 
     public function mapParameter(ReflectionParameter $refParameter, DocBlock $docBlock, ?Type $paramTagType, ParameterAnnotations $parameterAnnotations, ParameterHandlerInterface $next): ParameterInterface
     {
-        /** @var Assert[] $assertAnnotations */
-        $assertAnnotations = $parameterAnnotations->getAnnotationsByType(Assert::class);
+        /** @var Assertion[] $assertionAnnotations */
+        $assertionAnnotations = $parameterAnnotations->getAnnotationsByType(Assertion::class);
 
         $parameter = $next->mapParameter($refParameter, $docBlock, $paramTagType, $parameterAnnotations);
 
-        if (empty($assertAnnotations)) {
+        if (empty($assertionAnnotations)) {
             return $parameter;
         }
 
@@ -54,9 +55,9 @@ class AssertParameterMiddleware implements ParameterMiddlewareInterface
         }
 
         // Let's wrap the ParameterInterface into a ParameterValidator.
-        $recursiveConstraints = array_map(static function (Assert $assertAnnotation) {
+        $recursiveConstraints = array_map(static function (Assertion $assertAnnotation) {
             return $assertAnnotation->getConstraint();
-        }, $assertAnnotations);
+        }, $assertionAnnotations);
         $constraints = array_merge(...$recursiveConstraints);
 
         return new ParameterValidator($parameter, $refParameter->getName(), $constraints, $this->constraintValidatorFactory, $this->validator, $this->translator);

--- a/src/Mappers/Parameters/InvalidAssertionAnnotationException.php
+++ b/src/Mappers/Parameters/InvalidAssertionAnnotationException.php
@@ -7,7 +7,7 @@ namespace TheCodingMachine\Graphqlite\Validator\Mappers\Parameters;
 use Exception;
 use ReflectionParameter;
 
-class InvalidAssertAnnotationException extends Exception
+class InvalidAssertionAnnotationException extends Exception
 {
     public static function canOnlyValidateInputType(ReflectionParameter $refParameter): self
     {

--- a/tests/Annotations/AssertionTest.php
+++ b/tests/Annotations/AssertionTest.php
@@ -5,20 +5,20 @@ namespace TheCodingMachine\Graphqlite\Validator\Annotations;
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
 
-class AssertTest extends TestCase
+class AssertionTest extends TestCase
 {
 
     public function testException1()
     {
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('The @Assert annotation must be passed a target. For instance: "@Assert(for="$email", constraint=@Email)"');
-        new Assert([]);
+        new Assertion([]);
     }
 
     public function testException2()
     {
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('The @Assert annotation must be passed one or many constraints. For instance: "@Assert(for="$email", constraint=@Email)"');
-        new Assert(['for'=>'foo']);
+        new Assertion(['for'=>'foo']);
     }
 }

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -4,12 +4,12 @@
 namespace TheCodingMachine\Graphqlite\Validator\Fixtures\Controllers;
 
 
-use Symfony\Component\Validator\Constraints as Assertion;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\Graphqlite\Validator\Fixtures\Types\User;
-use TheCodingMachine\Graphqlite\Validator\Annotations\Assert;
+use TheCodingMachine\Graphqlite\Validator\Annotations\Assertion;
 use TheCodingMachine\Graphqlite\Validator\ValidationFailedException;
 
 class UserController
@@ -40,7 +40,7 @@ class UserController
 
     /**
      * @Query
-     * @Assert(for="email", constraint=@Assertion\Email())
+     * @Assertion(for="email", constraint=@Assert\Email())
      */
     public function findByMail(string $email = 'a@a.com'): User
     {

--- a/tests/Fixtures/InvalidControllers/InvalidController.php
+++ b/tests/Fixtures/InvalidControllers/InvalidController.php
@@ -5,18 +5,15 @@ namespace TheCodingMachine\Graphqlite\Validator\Fixtures\InvalidControllers;
 
 
 use GraphQL\Type\Definition\ResolveInfo;
-use Symfony\Component\Validator\Constraints as Assertion;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
-use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use Symfony\Component\Validator\Constraints as Assert;
 use TheCodingMachine\GraphQLite\Annotations\Query;
-use TheCodingMachine\Graphqlite\Validator\Annotations\Assert;
-use TheCodingMachine\Graphqlite\Validator\ValidationFailedException;
+use TheCodingMachine\Graphqlite\Validator\Annotations\Assertion;
 
 class InvalidController
 {
     /**
      * @Query
-     * @Assert(for="$resolveInfo", constraint=@Assertion\Email())
+     * @Assertion(for="$resolveInfo", constraint=@Assert\Email())
      */
     public function invalid(ResolveInfo $resolveInfo): string
     {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -23,7 +23,7 @@ use TheCodingMachine\GraphQLite\Exceptions\WebonyxErrorHandler;
 use TheCodingMachine\GraphQLite\SchemaFactory;
 use TheCodingMachine\Graphqlite\Validator\Fixtures\Controllers\UserController;
 use TheCodingMachine\Graphqlite\Validator\Mappers\Parameters\AssertParameterMiddleware;
-use TheCodingMachine\Graphqlite\Validator\Mappers\Parameters\InvalidAssertAnnotationException;
+use TheCodingMachine\Graphqlite\Validator\Mappers\Parameters\InvalidAssertionAnnotationException;
 use function var_dump;
 use function var_export;
 use const JSON_PRETTY_PRINT;
@@ -162,7 +162,7 @@ class IntegrationTest extends TestCase
         $schemaFactory->addControllerNamespace('TheCodingMachine\Graphqlite\Validator\Fixtures\InvalidControllers');
         $schema = $schemaFactory->createSchema();
 
-        $this->expectException(InvalidAssertAnnotationException::class);
+        $this->expectException(InvalidAssertionAnnotationException::class);
         $this->expectExceptionMessage('In method TheCodingMachine\Graphqlite\Validator\Fixtures\InvalidControllers\InvalidController::invalid(), the @Assert annotation is targeting parameter "$resolveInfo". You cannot target this parameter because it is not part of the GraphQL Input type. You can only assert parameters coming from the end user.');
         $schema->validate();
     }


### PR DESCRIPTION
The name change is useful because most Symfony examples use the "Assert" alias as a base for their annotation. The alias is not compatible with the Assert name (it causes a conflict)