### PR TITLE
Allow Symfony 6 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require" : {
     "php" : ">=7.2",
     "thecodingmachine/graphqlite" : "^5.0",
-    "symfony/validator": "^4.2 | ^5",
+    "symfony/validator": "^4.2 | ^5 | ^6",
     "doctrine/annotations": "^1.6"
   },
   "require-dev": {


### PR DESCRIPTION
This change allows the bundle to be used with Symfony 6 (which is already added to thecodingmachine/graphqlite@dev-master and thecodingmachine/graphqlite-bundle)