### PR TITLE
Upgrade Symfony vendor to ^6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require" : {
     "php" : ">=7.2",
     "thecodingmachine/graphqlite" : "^5.0",
-    "symfony/validator": "^4.2 | ^5",
+    "symfony/validator": "^4.2 | ^5 | ^6" ,
     "doctrine/annotations": "^1.6"
   },
   "require-dev": {
@@ -27,7 +27,7 @@
     "mouf/picotainer": "^1.1",
     "phpstan/phpstan": "^0.12.14",
     "php-coveralls/php-coveralls": "^2.1.0",
-    "symfony/translation": "^4",
+    "symfony/translation": "^4 | ^5 | ^6",
     "doctrine/coding-standard": "^9.0"
   },
   "scripts": {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -35,7 +35,8 @@ class IntegrationTest extends TestCase
             },
             ValidatorInterface::class => function(ContainerInterface $container) {
                 $build = new ValidatorBuilder();
-                $build->enableAnnotationMapping(new AnnotationReader());
+                $build->enableAnnotationMapping();
+                $build->setDoctrineAnnotationReader(new AnnotationReader());
                 $build->setTranslator($container->get(TranslatorInterface::class));
                 return $build->getValidator();
             },


### PR DESCRIPTION
# Description
This package still needs to be updated to Symfony ^6.

The existing PR #62 (which also aims to SF6) is not complete. It will fail tests due to a missing fix.
Since Validator ^6 the Doctrine annotation reader needs to be set specifically. @see https://github.com/symfony/validator/blob/6.1/CHANGELOG.md#60

### Failing `thecodingmachine/graphqlite-bundle:^5.4`:
The comment @oojacoboo added to #62 is incorrect. Installing `thecodingmachine/graphqlite-bundle` to the latest version `5.4` will fail when using SF6, due to the incompatibility of this package `thecodingmachine/graphqlite-symfony-validator-bridge`. The graphqlite bundle 5.4 is thereby broken, as said in https://github.com/thecodingmachine/graphqlite-bundle/issues/137

<img width="795" alt="Schermafbeelding 2022-09-29 om 08 37 29" src="https://user-images.githubusercontent.com/4119451/192958270-48da3887-b3a3-4179-9de0-33dd9cbb634c.png">

**Therefore, hereby a fixing PR to upgrade this bridge to SF6, so that the bundle can be fixed as well.**

## Changes
- [x] Upgraded alll Symfony packages to ^6.
- [x] Fixed all breaking changes due to the upgrade to 6