### PR TITLE
chore: Allow doctrine annotation 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php" : ">=8.1",
     "thecodingmachine/graphqlite" : "^6.0",
     "symfony/validator": "^6" ,
-    "doctrine/annotations": "^1.13"
+    "doctrine/annotations": "^1.13 || ^2.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.5",


### PR DESCRIPTION
As per upgrade notes I don't see any breakage for this package:

https://github.com/doctrine/annotations/blob/2.0.x/UPGRADE.md