### PR TITLE
:sparkles: Support for using attribute as a target to parameter…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "doctrine/coding-standard": "^11.1|^12.0"
   },
   "scripts": {
-    "phpstan": "phpstan analyse src/ -c phpstan.neon --level=7 --no-progress",
+    "phpstan": "phpstan analyse --no-progress",
     "cs-check": "phpcs",
     "cs-fix": "phpcbf",
     "test": ["@cs-check", "@phpstan", "phpunit"]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,9 @@
 parameters:
+    level: 7
+
+    paths:
+        - src
+
     ignoreErrors:
 
     excludePaths:

--- a/src/Annotations/Assertion.php
+++ b/src/Annotations/Assertion.php
@@ -15,6 +15,10 @@ use function ltrim;
 /**
  * Use this annotation to validate a parameter for a query or mutation.
  *
+ * Note 1: using this attribute as a target to the method (not parameter) is deprecated and will be removed in 8.0.
+ * Note 2: support for `doctrine/annotations` will be removed in 8.0.
+ * Note 3: this class won't implement `ParameterAnnotationInterface` in 8.0.
+ *
  * @Annotation
  * @Target({"METHOD"})
  * @Attributes({
@@ -22,10 +26,10 @@ use function ltrim;
  *   @Attribute("constraint", type = "Symfony\Component\Validator\Constraint[]|Symfony\Component\Validator\Constraint")
  * })
  */
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 class Assertion implements ParameterAnnotationInterface
 {
-    private string $for;
+    private ?string $for = null;
     /** @var Constraint[] */
     private array $constraint;
 
@@ -40,20 +44,24 @@ class Assertion implements ParameterAnnotationInterface
     ) {
         $for = $for ?? $values['for'] ?? null;
         $constraint = $constraint ?? $values['constraint'] ?? null;
-        if ($for === null) {
-            throw new BadMethodCallException('The Assert attribute must be passed a target. For instance: "#[Assert(for: "$email", constraint: new Email())"');
-        }
 
         if ($constraint === null) {
-            throw new BadMethodCallException('The Assert attribute must be passed one or many constraints. For instance: "#[Assert(for: "$email", constraint: new Email())"');
+            throw new BadMethodCallException('The Assertion attribute must be passed one or many constraints. For instance: "#[Assertion(constraint: new Email())"');
         }
 
-        $this->for = ltrim($for, '$');
         $this->constraint = is_array($constraint) ? $constraint : [$constraint];
+
+        if (null !== $for) {
+            $this->for = ltrim($for, '$');
+        }
     }
 
     public function getTarget(): string
     {
+        if ($this->for === null) {
+            throw new BadMethodCallException('The Assertion attribute must be passed a target. For instance: "#[Assertion(for: "$email", constraint: new Email())"');
+        }
+
         return $this->for;
     }
 

--- a/src/Annotations/Assertion.php
+++ b/src/Annotations/Assertion.php
@@ -52,6 +52,12 @@ class Assertion implements ParameterAnnotationInterface
         $this->constraint = is_array($constraint) ? $constraint : [$constraint];
 
         if (null !== $for) {
+            trigger_error(
+                "Using #[Assertion(for='" . $for . "', constaint='...')] on methods is deprecated in favor " .
+                "of #[Assertion(constraint='...')] the parameter itself.",
+                E_USER_DEPRECATED,
+            );
+
             $this->for = ltrim($for, '$');
         }
     }

--- a/src/Annotations/Assertion.php
+++ b/src/Annotations/Assertion.php
@@ -11,6 +11,9 @@ use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotationInterface;
 
 use function is_array;
 use function ltrim;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Use this annotation to validate a parameter for a query or mutation.
@@ -29,7 +32,7 @@ use function ltrim;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PARAMETER)]
 class Assertion implements ParameterAnnotationInterface
 {
-    private ?string $for = null;
+    private string|null $for = null;
     /** @var Constraint[] */
     private array $constraint;
 
@@ -51,15 +54,17 @@ class Assertion implements ParameterAnnotationInterface
 
         $this->constraint = is_array($constraint) ? $constraint : [$constraint];
 
-        if (null !== $for) {
-            trigger_error(
-                "Using #[Assertion(for='" . $for . "', constaint='...')] on methods is deprecated in favor " .
-                "of #[Assertion(constraint='...')] the parameter itself.",
-                E_USER_DEPRECATED,
-            );
-
-            $this->for = ltrim($for, '$');
+        if ($for === null) {
+            return;
         }
+
+        trigger_error(
+            "Using #[Assertion(for='" . $for . "', constaint='...')] on methods is deprecated in favor " .
+            "of #[Assertion(constraint='...')] the parameter itself.",
+            E_USER_DEPRECATED,
+        );
+
+        $this->for = ltrim($for, '$');
     }
 
     public function getTarget(): string

--- a/tests/Annotations/AssertionTest.php
+++ b/tests/Annotations/AssertionTest.php
@@ -9,17 +9,10 @@ use PHPUnit\Framework\TestCase;
 
 class AssertionTest extends TestCase
 {
-    public function testException1(): void
-    {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('The Assert attribute must be passed a target. For instance: "#[Assert(for: "$email", constraint: new Email())"');
-        new Assertion([]);
-    }
-
     public function testException2(): void
     {
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('The Assert attribute must be passed one or many constraints. For instance: "#[Assert(for: "$email", constraint: new Email())"');
+        $this->expectExceptionMessage('The Assertion attribute must be passed one or many constraints. For instance: "#[Assertion(constraint: new Email())"');
         new Assertion(['for' => 'foo']);
     }
 }

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -35,8 +35,17 @@ class UserController
 
     #[Query]
     #[Assertion(for: '$email', constraint: new Assert\Email())]
-    public function findByMail(string $email = 'a@a.com'): User
+    public function findByMailTargetMethod(string $email = 'a@a.com'): User
     {
+        // deprecated way of using the Assertion annotation - as a target of the method
+        return new User($email, 'foo');
+    }
+
+    #[Query]
+    public function findByMail(
+        #[Assertion(constraint: new Assert\Email())]
+        string $email = 'a@a.com',
+    ): User {
         return new User($email, 'foo');
     }
 }

--- a/tests/Fixtures/InvalidControllers/InvalidController.php
+++ b/tests/Fixtures/InvalidControllers/InvalidController.php
@@ -12,9 +12,10 @@ use TheCodingMachine\GraphQLite\Validator\Annotations\Assertion;
 class InvalidController
 {
     #[Query]
-    #[Assertion(for: '$resolveInfo', constraint: new Assert\Email())]
-    public function invalid(ResolveInfo $resolveInfo): string
-    {
+    public function invalid(
+        #[Assertion(for: '$resolveInfo', constraint: new Assert\Email())]
+        ResolveInfo $resolveInfo,
+    ): string {
         return 'foo';
     }
 }


### PR DESCRIPTION
…Deprecate using as a target to the method. Add warning about next major release changes

These changes can be released with a minor tag release (introduced new feature).

Refs: https://github.com/thecodingmachine/graphqlite/issues/708#issuecomment-2484300197