### PR TITLE
Support both Symfony 6 and 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require" : {
     "php" : ">=8.1",
     "thecodingmachine/graphqlite" : "^7.0 || ^8.0",
-    "symfony/validator": "^7"
+    "symfony/validator": "^6.4 || ^7"
   },
   "require-dev": {
     "phpunit/phpunit": "^11",


### PR DESCRIPTION
With version 7.0.0 we dropped support for Symfony 6, but the latest versions of the main library [graphqlite](https://github.com/thecodingmachine/graphqlite) still support both Symfony 6 and 7.

So, with this PR we reintroduce the support for Symfony 6.